### PR TITLE
PAPI.jl for Julia 0.6.x

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4-
-BinDeps 0.3.7-
-FactCheck 0.2.3-
+julia 0.6-
+BinDeps 0.8.6-
+FactCheck 0.4.3-

--- a/src/PAPI.jl
+++ b/src/PAPI.jl
@@ -1,7 +1,8 @@
 module PAPI
 
-@osx_only error("PAPI.jl currently only works on Linux")
-@windows_only error("PAPI.jl currently only works on Linux")
+@static if is_apple() || is_windows()
+    error("PAPI.jl currently only works on Linux")
+end
 
 include("events.jl")
 include("retcodes.jl")

--- a/src/events.jl
+++ b/src/events.jl
@@ -1,5 +1,5 @@
 @enum(Event,
-    L1_DCM = 0x80000000,  # Level 1 data cache misses
+    L1_DCM = -2147483648,  # Level 1 data cache misses
     L1_ICM,  # Level 1 instruction cache misses
     L2_DCM,  # Level 2 data cache misses
     L2_ICM,  # Level 2 instruction cache misses

--- a/src/retcodes.jl
+++ b/src/retcodes.jl
@@ -27,7 +27,7 @@
       ECOMBO =  -24,    # Bad combination of  features
 )
 
-const errmsg = let msgs = Dict{RetCode,ASCIIString}(
+const errmsg = let msgs = Dict{RetCode, String}(
         OK => "OK",
         EINVAL => "Invalid argument",
         ENOMEM => "Insufficient memory",


### PR DESCRIPTION
Hi Jake,

I made a few improvements to make PAPI.jl usable on Julia 0.6.x. I hope you might find this useful.

Best regards,
- Patryk Kiepas